### PR TITLE
Fixed warning about headers already sent

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,8 +1,8 @@
 <?php
-    require_once('./support/meekrodb.2.3.class.php');
-    require_once('./support/dba.php');
-
     session_start();
+
+    require_once('./support/meekrodb.2.3.class.php');
+    require_once('./support/dba.php');    
 
     if (isset($_GET['logout'])) {
         unset($_SESSION['authenticated']);

--- a/support/dba.php
+++ b/support/dba.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
     DB::$user = 'tlvUser';
     DB::$password = 'tlvUser';
     DB::$dbName = 'tlv';


### PR DESCRIPTION
Leading spaces in config file triggerd header already sent warning.
Moved session_start to top and removed leading spaces in config file