### PR TITLE
Reorganise README and add files necessary for Docker+nginx deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:7-fpm-buster
+
+COPY sqstorage-master/ /app/
+RUN chown www-data:www-data -R /app/
+
+VOLUME /app
+
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install gettext
+
+RUN apt-get update && apt-get install -y zlib1g-dev libicu-dev g++
+
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl

--- a/README.md
+++ b/README.md
@@ -6,21 +6,35 @@ A easy to use and super quick way to organize your inventory, storage and storag
 Right now sqStorage available in German and English. Feel free to add your own translation (see LANGUAGE.md).
 
 ### Installation and usage
-1) By default, the database name used is **tlv** and the main user **tlvUser** with the password **tlvUser** - this can be configured in **support/dba.php** changing the ***DB::dbName***,  ***DB::$user*** and ***DB::$password*** variables, if you use a server, you might want to use the SQL Server IP instead of *localhost*.
-The directories **smartyfiles/** and **languages/locale/** need to be writeable for the webserver.
-**chown -R www-data smartyfiles/** and **chown -R www-data languages/locale/** should do it in most cases.
-You need to have the php intl extension enabled.
 
-2) Once the user and database are created, open `bootDB.php` this will create all db tables ready for usage.
+#### Requirements
 
-3) Open sqstorage and create a admin account - this can be done once after installation. If you mess up, you will have to drop/truncate the following tables in order to prompt for the admin account registration again.
+* PHP version 7.0 and upwards
+  * PHP extensions: `mysqli`, `gettext`, `intl`
+* a MySQL-compatible database server (e.g. MariaDB)
+* a web server, e.g. nginx or Apache.
 
-The tables are:
-* users
+#### Database
 
-Then open `bootDB.php` again to recreate the tables.
+Default database: `tlv`
+Default username: `tlvUser`
+Default password: `tlvUser`
 
-Last but not least:
+This can be configured in `support/dba.php` by changing the `DB::dbName`, `DB::$user` and `DB::$password` variables. If your database is on a different server, you might want to use the IP or hostname instead of `localhost`.
 
-4) Have fun using sqStorage and do not hesitate to write a email or issue, if you miss something!
+#### Permissions
 
+The directories `smartyfiles/` and `languages/locale/` need to be **writeable** for the webserver.
+
+`chown -R www-data smartyfiles/` and `chown -R www-data languages/locale/` should work in most cases.
+
+#### First run
+
+- Once user and database are created, open `bootDB.php`. This will create all DB tables necessary.
+- Open sqstorage in your webbrowser and create a admin account.
+  * this can be done only once after installation!
+  * If you mess up, you will have to drop/truncate the `users` table in order to prompt for admin account registration again. You will have to open `bootDB.php` again to recreate the tables.
+
+#### Last but not least
+
+Have fun using sqStorage and do not hesitate to write a email or issue, if you miss something!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.0"
+
+services:
+  php:
+    image: sqstorage:master
+    volumes:
+      - "app:/app"
+      - "./dba.php:/app/support/dba.php:ro"
+
+  db:
+    image: mariadb:10.4
+    environment:
+      - MYSQL_DATABASE=tlv
+      - MYSQL_USER=tlvUser
+      - MYSQL_PASSWORD=tlvUser
+      - MYSQL_RANDOM_ROOT_PASSWORD=yes
+
+  web:
+    image: nginx:alpine
+    ports:
+      - "1337:80"
+    volumes:
+      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+      - "app:/app"
+
+volumes:
+  app:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /app;
+
+    rewrite ^/(inventory|categories|transfer|settings|datafields)$ /$1.php?$args;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}


### PR DESCRIPTION
Should be pretty obvious. README was missing information about requirements of gettext and mysqli. I restructured it a bit, too. Additionally I added an `nginx.conf` working for php-fpm and a `Dockerfile` and `docker-compose.yml` for easy deployment. #worksforme

As soon as we find a solution for #11 I will happily write documentation on how to run this with Docker(-Compose) easily. For now it works like this:

* `wget https://github.com/jrie/sqstorage/archive/master.zip`
* `unzip master.zip`
* `cp sqstorage-master/Dockerfile sqstorage-master/docker-compose.yml sqstorage-master/nginx.conf sqstorage-master/support/dba.php .`
* `sed -i 's/localhost/db/' dba.php`
* `docker build --no-cache -t sqstorage:master .`
* `docker-compose up -d`

We could probably publish this to Docker Hub when the requirement to copy/edit `dba.php` is gone. Then it could work like this:

* `wget https://raw.githubusercontent.com/jrie/sqstorage/master/docker-compose.yml`
* edit `.env` file which contains DB credentials
* open browser to sqstorage.

Possibly we could skip the admin user creation process too with #20.