### PR TITLE
Refactor some typos, whitespace and code duplication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-fpm-buster
 
-COPY sqstorage-master/ /app/
+COPY ./ /app/
 RUN chown www-data:www-data -R /app/
 
 VOLUME /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.0"
 services:
   php:
     image: sqstorage:master
+    build: .
     volumes:
-      - "app:/app"
-      - "./dba.php:/app/support/dba.php:ro"
+      - "./:/app"
+      - "./dba.php:/app/support/dba.php:rw"
 
   db:
     image: mariadb:10.4
@@ -21,7 +22,7 @@ services:
       - "1337:80"
     volumes:
       - "./nginx.conf:/etc/nginx/conf.d/default.conf"
-      - "app:/app"
+      - "./:/app"
 
 volumes:
   app:

--- a/install.php
+++ b/install.php
@@ -150,10 +150,4 @@ function IsDirWriteable($folder){
   return $tmp;
 }
 
-
-
-
-
-
-
 exit;

--- a/languages/locale/de_DE/messages.po
+++ b/languages/locale/de_DE/messages.po
@@ -139,8 +139,8 @@ msgid "Datenbank-Port"
 msgstr "Datenbank-Port"
 
 #: templates//installpage.tpl:94
-msgid "Verbinungsdaten eintragen"
-msgstr "Verbinungsdaten eintragen"
+msgid "Verbindungsdaten eintragen"
+msgstr "Verbindungsdaten eintragen"
 
 #: templates//installpage.tpl:99
 msgid "Datenbank installieren / aktualisieren"

--- a/languages/locale/en_GB/messages.po
+++ b/languages/locale/en_GB/messages.po
@@ -139,7 +139,7 @@ msgid "Datenbank-Port"
 msgstr "Database port"
 
 #: templates//installpage.tpl:94
-msgid "Verbinungsdaten eintragen"
+msgid "Verbindungsdaten eintragen"
 msgstr "Enter credentials"
 
 #: templates//installpage.tpl:99

--- a/languages/sqstorage.pot
+++ b/languages/sqstorage.pot
@@ -126,7 +126,7 @@ msgid "Datenbank-Port"
 msgstr ""
 
 #: templates//installpage.tpl:94
-msgid "Verbinungsdaten eintragen"
+msgid "Verbindungsdaten eintragen"
 msgstr ""
 
 #: templates//installpage.tpl:99

--- a/support/install_permissions.php
+++ b/support/install_permissions.php
@@ -1,5 +1,45 @@
 <?php
 
+$header_template = <<<EOD
+<html>
+  <head>
+    <title>sqStorage - Installation</title>
+    <link rel="stylesheet" href="./css/bootstrap/bootstrap.css">
+    <link rel="stylesheet" href="./css/base.css">
+    <link rel="stylesheet" href="./fonts/fontawesome/css/solid.css">
+    <link rel="stylesheet" href="./fonts/fontawesome/css/regular.css">
+    <link rel="stylesheet" href="./fonts/fontawesome/css/fontawesome.css">
+    <meta charset="utf-8">
+  </head>
+  <body>
+  <nav class="navbar navbar-light bg-light">
+    <a href="index.php"><img class="logo" src="./img/sqstorage.png" alt="sqStorage logo" /></a>
+    <div class="dropdown">
+      <select class="form-control mr-sm-2" name="lang">
+        <option value="en_GB">English</option>
+        <option value="de_DE">Deutsch</option>
+      </select>
+      <script type ="text/javascript">
+          let langSelection = document.querySelector('select[name="lang"').addEventListener('change', function (evt) {
+              let langValue = evt.target.options[evt.target.selectedIndex].value
+              let srcUri = window.location.href.toString().replace(/.lang=.[^\&\/]*/, '')
+              if (srcUri.indexOf('?') === -1) window.location.href = srcUri + '?lang=' + langValue
+              else window.location.href = srcUri + '&lang=' + langValue
+          })
+      </script>
+    </div>
+  </nav>
+  <center>
+EOD;
+
+$footer_template = <<<EOD
+</center>
+<footer class="footer">
+  <script type="text/javascript">
+    eval(unescape("%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%22%6d%61%69%6c%74%6f%3a%6a%61%6e%40%64%77%72%6f%78%2e%6e%65%74%3f%73%75%62%6a%65%63%74%3d%73%71%73%74%6f%72%61%67%65%22%20%63%6c%61%73%73%3d%22%62%74%6e%20%62%74%6e%2d%69%6e%66%6f%22%20%74%61%62%69%6e%64%65%78%3d%22%2d%31%22%3e%4b%6f%6e%74%61%6b%74%3c%2f%61%3e%27%29%3b"))</script><a class="btn btn-info" tabIndex="-1" target="_blank" href="https://github.com/jrie/sqstorage">Github</a></footer></script>';
+</body></html>
+EOD;
+
 $wsun="www-data";
 if(function_exists("posix_getpwuid")){
 $poss =  posix_getpwuid(posix_geteuid());
@@ -19,38 +59,8 @@ if(!file_exists($basedir  . "/support/allow_install")){
 
   include_once("./support/language_tools.php");
 
-  echo '<html><head><title>sqStorage - Installation</title><link rel="stylesheet" href="./css/bootstrap/bootstrap.css"><link rel="stylesheet" href="./css/base.css"><link rel="stylesheet" href="./fonts/fontawesome/css/solid.css"><link rel="stylesheet" href="./fonts/fontawesome/css/regular.css"><link rel="stylesheet" href="./fonts/fontawesome/css/fontawesome.css"><meta charset="utf-8"></head><body>';
-  $desel = '';
-  $ensel = '';
-  if(isset($_SESSION['lang'])){
-        if($_SESSION['lang'] == 'en_GB') $ensel = 'selected="selected"';
-        if($_SESSION['lang'] == 'de_DE') $desel = 'selected="selected"';
-  }
+  echo $header_template;
 
-
-  ?>
-<nav class="navbar navbar-light bg-light">
-    <a href="index.php"><img class="logo" src="./img/sqstorage.png" alt="sqStorage logo" /></a>
-
-    <div class="dropdown">
-         <select class="form-control mr-sm-2" name="lang">
-                        <option value="en_GB" <?php echo $ensel; ?>>English</option>
-                        <option value="de_DE" <?php echo $desel; ?>>Deutsch</option>
-                    </select>
-        <script type ="text/javascript">
-            let langSelection = document.querySelector('select[name="lang"').addEventListener('change', function (evt) {
-                let langValue = evt.target.options[evt.target.selectedIndex].value
-                let srcUri = window.location.href.toString().replace(/.lang=.[^\&\/]*/, '')
-                if (srcUri.indexOf('?') === -1) window.location.href = srcUri + '?lang=' + langValue
-                else window.location.href = srcUri + '&lang=' + langValue
-            })
-        </script>
-    </div>
-
-
-</nav>
-  <?php
-  echo '</nav><center>';
   echo '<div class="alert alert-danger" role="alert">' . "<h3>". gettext("Die Installation ist momentan nicht erlaubt") . "</h3>";
   echo "<h4>" . gettext("Erstelle eine Datei mit dem Namen allow_install im Verzeichnis support um die Installation zu erlauben.") . "</h4>";
   echo "<h4>" . gettext("Verwendest Du eine bestehende Installation und die Benutzerverwaltung, kannst Du diese Datei als Administrator über das Einstellungen erstellen und nach der Aktualisierung auch wieder entfernen.") . "</h4>";
@@ -58,13 +68,11 @@ if(!file_exists($basedir  . "/support/allow_install")){
   echo '<div class="alert alert-info" role="alert">' . "<h4>". gettext("Unter Linux könnten folgende Befehle weiterhelfen") . "</h4>" ."</div>";
   echo '<div class="alert alert-light" role="alert">' ."<h4>sudo touch support/allow_install</h4></div>";
   ?>
-                    <form method="post">
-                    <input type="submit" value="<?php echo gettext("Erneut prüfen"); ?>" class="btn form-control btn-info">
-                    </form>
+    <form method="post">
+    <input type="submit" value="<?php echo gettext("Erneut prüfen"); ?>" class="btn form-control btn-info">
+    </form>
   <?php
-  echo "</center>";
-  echo '<footer class="footer"><script type="text/javascript">eval(unescape("%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%22%6d%61%69%6c%74%6f%3a%6a%61%6e%40%64%77%72%6f%78%2e%6e%65%74%3f%73%75%62%6a%65%63%74%3d%73%71%73%74%6f%72%61%67%65%22%20%63%6c%61%73%73%3d%22%62%74%6e%20%62%74%6e%2d%69%6e%66%6f%22%20%74%61%62%69%6e%64%65%78%3d%22%2d%31%22%3e%4b%6f%6e%74%61%6b%74%3c%2f%61%3e%27%29%3b"))</script><a class="btn btn-info" tabIndex="-1" target="_blank" href="https://github.com/jrie/sqstorage">Github</a></footer></script>';
-  echo '</body></html>';
+  echo $footer_template;
   exit();
 }
 
@@ -72,38 +80,8 @@ if(count($unwriteable)>0){
 
   include_once("./support/language_tools.php");
 
-  echo '<html><head><title>sqStorage - Installation</title><link rel="stylesheet" href="./css/bootstrap/bootstrap.css"><link rel="stylesheet" href="./css/base.css"><link rel="stylesheet" href="./fonts/fontawesome/css/solid.css"><link rel="stylesheet" href="./fonts/fontawesome/css/regular.css"><link rel="stylesheet" href="./fonts/fontawesome/css/fontawesome.css"><meta charset="utf-8"></head><body>';
-  $desel = '';
-  $ensel = '';
-  if(isset($_SESSION['lang'])){
-        if($_SESSION['lang'] == 'en_GB') $ensel = 'selected="selected"';
-        if($_SESSION['lang'] == 'de_DE') $desel = 'selected="selected"';
-  }
+  echo $header_template;
 
-
-  ?>
-<nav class="navbar navbar-light bg-light">
-    <a href="index.php"><img class="logo" src="./img/sqstorage.png" alt="sqStorage logo" /></a>
-
-    <div class="dropdown">
-         <select class="form-control mr-sm-2" name="lang">
-                        <option value="en_GB" <?php echo $ensel; ?>>English</option>
-                        <option value="de_DE" <?php echo $desel; ?>>Deutsch</option>
-                    </select>
-        <script type ="text/javascript">
-            let langSelection = document.querySelector('select[name="lang"').addEventListener('change', function (evt) {
-                let langValue = evt.target.options[evt.target.selectedIndex].value
-                let srcUri = window.location.href.toString().replace(/.lang=.[^\&\/]*/, '')
-                if (srcUri.indexOf('?') === -1) window.location.href = srcUri + '?lang=' + langValue
-                else window.location.href = srcUri + '&lang=' + langValue
-            })
-        </script>
-    </div>
-
-
-</nav>
-  <?php
-  echo '</nav><center>';
   echo '<div class="alert alert-danger" role="alert">' . "<h4>". gettext("Zugriff auf folgende Verzeichnisse fehlgeschlagen:") . "</h4>";
   foreach($unwriteable as $unw){
     echo "<h4>" . $unw . "</h4>";
@@ -114,12 +92,11 @@ if(count($unwriteable)>0){
   echo '<div class="alert alert-light" role="alert">' ."<h4>sudo chown -R $wsun $unw</h4><h4>sudo chgrp -R $wsun $unw</h4></div>";
   }
   ?>
-                    <form method="post">
-                    <input type="submit" value="<?php echo gettext("Erneut prüfen"); ?>" class="btn form-control btn-info">
-                    </form>
+    <form method="post">
+    <input type="submit" value="<?php echo gettext("Erneut prüfen"); ?>" class="btn form-control btn-info">
+    </form>
   <?php
-  echo "</center>";
-  echo '<footer class="footer"><script type="text/javascript">eval(unescape("%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%22%6d%61%69%6c%74%6f%3a%6a%61%6e%40%64%77%72%6f%78%2e%6e%65%74%3f%73%75%62%6a%65%63%74%3d%73%71%73%74%6f%72%61%67%65%22%20%63%6c%61%73%73%3d%22%62%74%6e%20%62%74%6e%2d%69%6e%66%6f%22%20%74%61%62%69%6e%64%65%78%3d%22%2d%31%22%3e%4b%6f%6e%74%61%6b%74%3c%2f%61%3e%27%29%3b"))</script><a class="btn btn-info" tabIndex="-1" target="_blank" href="https://github.com/jrie/sqstorage">Github</a></footer></script>';
-  echo '</body></html>';
+
+  echo $footer_template;
   exit();
 }

--- a/support/language_tools.php
+++ b/support/language_tools.php
@@ -1,25 +1,26 @@
 <?php
-
 define('LANGUAGEDIR', $basedir . '/languages/locale/');
 
-$langsAvailable = array('en_GB', 'de_DE');
 $langsLabels = array(
   'en_GB' => 'English',
   'de_DE' => 'Deutsch'
 );
-$defaultLanguage = $langsAvailable[count($langsAvailable) - 1];
-if (!isset($_SESSION)) session_start();
+$langsAvailable = array_keys($langsLabels);
+$defaultLanguage = 'de_DE';
+
+if (!isset($_SESSION)) {
+  session_start();
+  $_SESSION['lang'] = $defaultLanguage;
+}
+
 if (isset($_REQUEST['lang'])) {
   if (in_array($_REQUEST['lang'], $langsAvailable)) {
-    $newlang = $_REQUEST['lang'];
-    $_SESSION['lang'] = $newlang;
+    $_SESSION['lang'] = $_REQUEST['lang'];
   }
 }
 
-if (!isset($_SESSION['lang'])) $_SESSION['lang'] = $defaultLanguage;
 $langCurrent = $_SESSION['lang'];
 initLang($_SESSION['lang']);
-
 
 
 function initLang($locale)

--- a/support/tools.php
+++ b/support/tools.php
@@ -1,11 +1,4 @@
 <?php
-
-
-
-
-
-
-
 function CheckDBCredentials($host,$user,$password,$name,$port,$silent=false){
   global $error;
 

--- a/templates/installpage.tpl
+++ b/templates/installpage.tpl
@@ -91,7 +91,7 @@
                         <input type="text" name="dbport" maxlength="5" class="form-control" required="required" placeholder="3306" aria-label="{t}Datenbank-Port{/t}" aria-describedby="basic-addon1" value="{if isset($POST.dbport)}{$POST.dbport}{else}3306{/if}">
                 </div>
 
-                <input type="submit" class="btn form-control btn-success" value="{t}Verbinungsdaten eintragen{/t}">
+                <input type="submit" class="btn form-control btn-success" value="{t}Verbindungsdaten eintragen{/t}">
             {else}
                 {if count($MigMessages) < 1}
                   {if count($error) < 1}


### PR DESCRIPTION
Seems to work, but YMMV while selecting a language.

Probably header and footer should be moved to Smarty templates.

Interestingly, Smarty templates themselves have quite a lot of duplication in the inline JS department. The usage of blocks could mitigate that a little.

I suggest the authors of this software read [The Pragmatic Programmer – your journey to mastery, 20th anniversary edition, chapter 9 "The Evils of Duplication"](https://media.pragprog.com/titles/tpp20/dry.pdf) (freely available on the Internet).