### PR TITLE
smarty force_compile no longer hard coded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ support/dba.php
 smartyfolders/touchfile.txt
 support/smarty_debug
 patch.diff
+support/smarty_force_compile

--- a/README.md
+++ b/README.md
@@ -73,7 +73,18 @@ Default usePrettyURLs: `true`
 
 ***Please note the user registration and login/logout*** can be enabled by setting the variable `$useRegistration` to `true`, otherwise the default disables this feature by setting this to `false`.
 
-Also `$usePrettyURLs` can be set to `false` in order to disable pretty urls. ***This might resolve some errors on Raspberry OS***.
+If you are planning to use `$usePrettyURLs` on **Raspberry OS** please ensure that the apache2 site configuration allows the usage of `.htaccess`.
+This can be achieved by adding 
+```
+<Directory /var/www/html>
+	Options Indexes FollowSymLinks
+	AllowOverride All
+	Require all granted
+</Directory>
+```
+to the `/etc/apache2/sites-enabled/000-default.conf` site configuration (don't forget to restart apache afterwards `systemctl restart apache2`)
+
+Alternatively `$usePrettyURLs` can be set to `false` in order to disable pretty urls. ***This might resolve some errors on Raspberry OS***.
 
 #### Permissions and error 500
 

--- a/support/smartyconfig.php
+++ b/support/smartyconfig.php
@@ -26,5 +26,8 @@ if(file_exists('support/smarty_debug')){
 }else{
   $smarty->debugging = false;
 }
-$smarty->force_compile = true;
-//$smarty->display('index.tpl');
+if(file_exists('support/smarty_force_compile')){
+  $smarty->force_compile = true;
+}else{
+  $smarty->force_compile = false;
+}


### PR DESCRIPTION
smartyconfig adjusted to enable / disable the forced recompilation of the Smarty templates based on 
the existence of the file 'support/smarty_force_compile'
For productive use this file shouldn't be available to speed up the application
(difference on low performing systems [f.e. Raspberry Pi] is significant)
.gitignore extended to ignore 'support/smarty_force_compile'