### PR TITLE
Provides customFields-Data with the main item (myitem) array

### DIFF
--- a/inventory.php
+++ b/inventory.php
@@ -451,8 +451,9 @@ if (!isset($items)) $items = array();
  */
 //GetCustomFieldsConfiguration() -->>  retval[ CategoryID oder All][customFieldsID][id/label/dataType/defau...]
 
-$cfconf = GetCustomFieldsConfiguration();
 $cfraw = DB::query('SELECT * FROM customFields');
+$cfconf = GetCustomFieldsConfiguration($cfraw);
+
 $cfdata = GetItemBasedCFD($cfraw);
 
 

--- a/inventory.php
+++ b/inventory.php
@@ -450,8 +450,12 @@ if (!isset($items)) $items = array();
  * CustomFields....
  */
 //GetCustomFieldsConfiguration() -->>  retval[ CategoryID oder All][customFieldsID][id/label/dataType/defau...]
-$cfdata = DB::query('SELECT * FROM fieldData');
+
 $cfconf = GetCustomFieldsConfiguration();
+$cfraw = DB::query('SELECT * FROM customFields');
+$cfdata = GetItemBasedCFD($cfraw);
+
+
 foreach($myitem as $itemL1 => $itemD1){
       for($x = 0; $x < count($itemD1['items']);$x++){
             $tocheck = array();
@@ -462,6 +466,9 @@ foreach($myitem as $itemL1 => $itemD1){
 
       }
 }
+
+
+
  /**
   * ....customFields
   */

--- a/inventory.php
+++ b/inventory.php
@@ -446,6 +446,27 @@ for ($x = 0; $x < count($subarray); $x++) {
 }
 if (!isset($items)) $items = array();
 
+/**
+ * CustomFields....
+ */
+//GetCustomFieldsConfiguration() -->>  retval[ CategoryID oder All][customFieldsID][id/label/dataType/defau...]
+$cfdata = DB::query('SELECT * FROM fieldData');
+$cfconf = GetCustomFieldsConfiguration();
+foreach($myitem as $itemL1 => $itemD1){
+      for($x = 0; $x < count($itemD1['items']);$x++){
+            $tocheck = array();
+            $tocheck[] = 'all';
+            $tocheck[] = $itemD1['items'][$x]['headcategory'];
+            //$itemdatafields = GetDataFields($tocheck,$cfconf,$cfdata);
+            $myitem[$itemL1]['items'][$x]['customFields'] = GetDataFields($tocheck,$cfconf,$cfdata,$itemD1['items'][$x]['id']);
+
+      }
+}
+ /**
+  * ....customFields
+  */
+
+
 //$smarty->assign('dump',print_r(array($sql,$categories,$subcategories,$storages,$myitem,$items),true));
 //$smarty->assign('dump',print_r(array($myitem,$items),true));
 

--- a/support/tools.php
+++ b/support/tools.php
@@ -40,16 +40,11 @@ function GetDataFields($tocheck,$cfconf,$cfdata,$itemid){
   foreach($tocheck as $catmark){
       if(isset( $cfconf[$catmark] )){
           foreach( $cfconf[$catmark] as $cfid  => $cfsdata  ){
-              $dfval = $cfsdata['default'];
-
-              //$dfval .= " (default)";
-
               if( isset($cfdata[$itemid][$cfid])  ){
-                $dfval = $cfdata[$itemid][$cfid];
+                $retval[$cfsdata['label']] = $cfdata[$itemid][$cfid];
+              }else{
+                $retval[$cfsdata['label']] = $cfsdata['default'];
               }
-              $retval[$cfsdata['label']] = $dfval;
-
-
           }
       }
   }

--- a/support/tools.php
+++ b/support/tools.php
@@ -39,13 +39,12 @@ function GetDataFields($tocheck,$cfconf,$cfdata,$itemid){
   $retval = array();
   foreach($tocheck as $catmark){
       if(isset( $cfconf[$catmark] )){
-          foreach( $cfconf[$catmark] as $cfid  => $cfdata  ){
-              $dfval = $cfdata['default'];
-
+          foreach( $cfconf[$catmark] as $cfid  => $cfsdata  ){
+              $dfval = $cfsdata['default'];
               if( isset($cfdata[$itemid][$cfid])  ){
                 $dfval = $cfdata[$itemid][$cfid];
               }
-              $retval[$cfdata['label']] = $dfval;
+              $retval[$cfsdata['label']] = $dfval;
 
 
           }
@@ -60,15 +59,16 @@ function GetItemBasedCFD($customFieldsRaw){
     $fnames = array('intNeg','intPos','intNegPos','floatNeg','floatPos','string','selection','mselection');
     $cflookupfield = array();
     for($x = 0; $x < count($customFieldsRaw);$x++){
-      $cflookupfield[ $customFieldsRaw[$x]['id'] ] = $customFieldsRaw[$x]['datatype'];
+      $cflookupfield[ $customFieldsRaw[$x]['id'] ] = $customFieldsRaw[$x]['dataType'];
     }
     $out = array();
     $cfb = DB::query('SELECT * FROM fieldData');
     for($x=0;$x < count($cfb);$x++){
         $cf = $cfb[$x];
-        $lookupfield = $fnames[ $cf['fieldId']  ];
-        $out[$cf['itemID']][$cf['fieldId']] = $cf[$lookupfield];
+        $lookupfield = $fnames[ $cflookupfield[ $cf['fieldId'] ]  ];
+        $out[$cf['itemId']][$cf['fieldId']] = $cf[$lookupfield];
     }
+
 return $out;
 }
 

--- a/support/tools.php
+++ b/support/tools.php
@@ -41,6 +41,9 @@ function GetDataFields($tocheck,$cfconf,$cfdata,$itemid){
       if(isset( $cfconf[$catmark] )){
           foreach( $cfconf[$catmark] as $cfid  => $cfsdata  ){
               $dfval = $cfsdata['default'];
+
+              //$dfval .= " (default)";
+
               if( isset($cfdata[$itemid][$cfid])  ){
                 $dfval = $cfdata[$itemid][$cfid];
               }
@@ -73,10 +76,9 @@ return $out;
 }
 
 
-function GetCustomFieldsConfiguration(){
+function GetCustomFieldsConfiguration($cfs){
   // workdb [ CategoryID oder All][customFieldsID]
   $workcfsw = array();
-  $cfs = DB::query("Select * from customFields");
   for ($x=0;$x < count($cfs); $x++){
       $cfsw[$cfs[$x]['id']] = $cfs[$x];
   }


### PR DESCRIPTION
Extends each item within $myitems with the custom fields applicable to the headCategory as well as the data (default value is no individual value was set). Data is written in the "customFields" element of the items.

Example output
Array (5)
1 => Array (4)
  storage => Array (3)
    id => "1"
    label => "SMD-Box"
    amount => "88"
  positionen => 13
  itemcount => 883
  items => Array (13)
    0 => Array (10)
      id => "1"
      label => "Kondensator, 1206, 10000pF"
      comment => "keine"
      date => "2022-07-07 16:30:33"
      serialnumber => null
      amount => "40"
      headcategory => "1"
      subcategories => ",2,1,"
      storageid => "1"
      customFields => Array (3)
        Zustand => "Neu"
        Spannung => "5V"
        InternerWiderstand => "0"
    1 => Array (10)
      id => "2"
      label => "Widerstand, 1206, 100K"
      comment => null
      date => "2022-07-07 16:34:02"
      serialnumber => null
      amount => "20"
      headcategory => "1"
      subcategories => ",1,3,"
      storageid => "1"
      customFields => Array (3)
        Zustand => "Neu"
        Spannung => "5V"
        InternerWiderstand => "0"
    2 => Array (10)
      id => "3"
...
`