### PR TITLE
Fixing users_group design by adding new primary key, removing old one…

### DIFF
--- a/support/database_migration/dbm_005.php
+++ b/support/database_migration/dbm_005.php
@@ -1,0 +1,5 @@
+<?php
+
+DB::query('ALTER TABLE `users_groups` DROP PRIMARY KEY;');
+DB::query('ALTER TABLE `users_groups` CHANGE `userid` `userid` BIGINT(20) UNSIGNED NOT NULL;');
+DB::query('ALTER TABLE `users_groups` ADD `id` INT NOT NULL AUTO_INCREMENT FIRST, ADD PRIMARY KEY (`id`);');

--- a/support/tools.php
+++ b/support/tools.php
@@ -164,8 +164,8 @@ function SettingsSet($namespace,$setting,$value){
   *
   */
 function AssignUserToGroup($userid,$groupid){
-      $isthere = DB::query('SELECT * FROM users_groups WHere userid = %i',$userid);
-      if($isthere === null){
+      $isRegisteredUser = DB::query('SELECT * FROM users_groups WHere userid = %i LIMIT 1',$userid);
+      if($isRegisteredUser === null){
           DB::insert('users_groups', ['userid' => $userid, 'usergroupid' => $groupid ]);
       }else{
           DB::query('UPDATE users_groups SET usergroupid = %i WHERE userid = %i',$groupid,$userid);
@@ -173,7 +173,7 @@ function AssignUserToGroup($userid,$groupid){
 }
 
 function DeleteUser($userid){
-      DB::query('DELETE FROM users_groups WHere userid = %i',$userid);
+      DB::query('DELETE FROM users_groups WHERE userid = %i',$userid);
       DB::query('DELETE FROM users WHERE id=%i', $userid);
 }
 

--- a/support/tools.php
+++ b/support/tools.php
@@ -164,7 +164,7 @@ function SettingsSet($namespace,$setting,$value){
   *
   */
 function AssignUserToGroup($userid,$groupid){
-      $isRegisteredUser = DB::query('SELECT * FROM users_groups WHere userid = %i LIMIT 1',$userid);
+      $isRegisteredUser = DB::queryFirstRow('SELECT * FROM users_groups WHere userid = %i LIMIT 1',$userid);
       if($isRegisteredUser === null){
           DB::insert('users_groups', ['userid' => $userid, 'usergroupid' => $groupid ]);
       }else{

--- a/support/tools.php
+++ b/support/tools.php
@@ -155,3 +155,30 @@ function SettingsSet($namespace,$setting,$value){
 /**
  * End Settings Tools
  */
+
+
+ /**
+  * User-Group and User Tools
+  *
+  * AssignUserToGroup($userid,$groupid) -> Assignes a group to a user, if user already in a group the record will be updated
+  *
+  */
+function AssignUserToGroup($userid,$groupid){
+      $isthere = DB::query('SELECT * FROM users_groups WHere userid = %i',$userid);
+      if($isthere === null){
+          DB::insert('users_groups', ['userid' => $userid, 'usergroupid' => $groupid ]);
+      }else{
+          DB::query('UPDATE users_groups SET usergroupid = %i WHERE userid = %i',$groupid,$userid);
+      }
+}
+
+function DeleteUser($userid){
+      DB::query('DELETE FROM users_groups WHere userid = %i',$userid);
+      DB::query('DELETE FROM users WHERE id=%i', $userid);
+}
+
+
+  /**
+   * End User-Group Tools
+   */
+


### PR DESCRIPTION
… as well as auto_increment on userid in users_group

Added functions to assign a group  to an user (AssignUserToGroup) as well as to delete a user (DeleteUser)
Fixed settings.php:
	if $_POST['target'] is set, $mtarget is set to the value defined (raised an NOTICE in some situations before)
	Using of AssignUserToGroup and DeleteUser

Fixes #90 